### PR TITLE
feat: typography foundation 작업

### DIFF
--- a/src/styles/foundation/typography/typography.mdx
+++ b/src/styles/foundation/typography/typography.mdx
@@ -5,8 +5,11 @@ import * as TypographyStories from "./typography.stories";
 
 # Typography System
 
-Woori Design System의 타이포그래피 시스템입니다.
-WDS는 모든 환경에서 일관된 타이포그래피를 제공합니다.
+Woori Design System의 대표 타이포그래피 시스템입니다.
+
+- 폰트는 **Pretendard**를 사용합니다.
+- 굵기는 Rg(400), Md(500), Sb(600) 3가지가 있습니다.
+- 타이포그래피의 이름은 `[굵기]_[크기]` 형식으로 명명됩니다.
 
 <br />
 
@@ -14,118 +17,32 @@ WDS는 모든 환경에서 일관된 타이포그래피를 제공합니다.
 
 Woori Design System에서는 theme.typography 객체를 통해 타이포그래피 토큰을 JavaScript 객체로 제공합니다.
 
-React, Next.js 등 JS 기반 프로젝트에서는 아래와 같이 사용할 수 있습니다:
+React, Next.js 등 JS 기반 프로젝트에서 아래와 같이 사용할 수 있습니다
+
+<br />
+
+### inline style 방식
 
 ```tsx
 import { theme } from "woori-design";
 
-const MyComponent = () => (
-  <div
-    style={{
-      fontFamily: theme.typography.Rg_t5.fontFamily,
-      fontWeight: theme.typography.Rg_t5.fontWeight,
-      fontSize: theme.typography.Rg_t5.fontSize,
-    }}
-  >
-    타이포그래피가 적용된 텍스트입니다.
-  </div>
-);
+const MyComponent = () => <div style={typography.Rg_14}>타이포그래피가 적용된 텍스트입니다.</div>;
+```
+
+### styled-components/emotion 방식
+
+```tsx
+import { theme } from "woori-design";
+
+const Box = styled.div`
+  ${typography.Sb_20}
+`;
 ```
 
 <br />
 
 ## Typography Token System
 
-Woori Design System은 세 가지 주요 폰트 웨이트와 t1부터 t10까지의 체계적인 폰트 사이즈를 제공합니다.
+모든 타이포그래피 스타일은 아래에서 확인할 수 있습니다.
 
-<br />
-
-### 1. Font Family
-
-우리 디자인 시스템은 **Pretendard**를 기본 폰트로 사용합니다.
-
-```css
-font-family: "Pretendard", "sans-serif";
-```
-
-### 2. Token Naming
-
-각 타이포그래피 토큰은 `WD-[웨이트]_t[사이즈]` 형식으로 명명됩니다.
-
-- **WD**: Woori Design의 약자
-- **[웨이트]**: Rg(Regular), Md(Medium), SB(SemiBold)
-- **t[사이즈]**: t1부터 t10까지의 사이즈 체계
-
-<br />
-
-### 3. Font Weights
-
-타이포그래피 시스템은 다음 세 가지 웨이트를 제공합니다:
-
-| 웨이트 코드 | 웨이트 이름 | 웨이트 값 |
-| ----------- | ----------- | --------- |
-| Rg          | Regular     | 400       |
-| Md          | Medium      | 500       |
-| SB          | SemiBold    | 600       |
-
-<br />
-
-### 4. Font Sizes
-
-타이포그래피 시스템은 t1부터 t10까지 10가지 사이즈를 제공합니다:
-
-| 사이즈 코드 | 픽셀 값 | rem 값    |
-| ----------- | ------- | --------- |
-| t1          | 11px    | 0.6875rem |
-| t2          | 12px    | 0.75rem   |
-| t3          | 13px    | 0.8125rem |
-| t4          | 14px    | 0.875rem  |
-| t5          | 16px    | 1rem      |
-| t6          | 18px    | 1.125rem  |
-| t7          | 20px    | 1.25rem   |
-| t8          | 22px    | 1.375rem  |
-| t9          | 24px    | 1.5rem    |
-| t10         | 26px    | 1.625rem  |
-
-<br />
-
-### 5. Line Height
-
-기본 라인 하이트는 1.5로 설정되어 있습니다. 필요에 따라 개별 토큰에 다른 라인 하이트를 지정할 수 있습니다.
-
-```typescriptreact
-// 기본 라인 하이트
-export const defaultLineHeight = 1.5;
-```
-
-### 6. Weight & Size Combinations
-
-#### (1) Regular (Rg, 400)
-
-기본 본문 텍스트에 사용됩니다. 대부분의 일반 텍스트 콘텐츠에 적합합니다.
-
-| 이름      | 설명         | 값               |
-| --------- | ------------ | ---------------- |
-| WD-Rg_t1  | Regular 11px | 0.6875rem (11px) |
-| WD-Rg_t5  | Regular 16px | 1rem (16px)      |
-| WD-Rg_t10 | Regular 26px | 1.625rem (26px)  |
-
-#### (2) Medium (Md, 500)
-
-중요도가 약간 높은 텍스트나 서브 헤딩에 사용됩니다.
-
-| 이름      | 설명        | 값               |
-| --------- | ----------- | ---------------- |
-| WD-Md_t1  | Medium 11px | 0.6875rem (11px) |
-| WD-Md_t5  | Medium 16px | 1rem (16px)      |
-| WD-Md_t10 | Medium 26px | 1.625rem (26px)  |
-
-#### (3) SemiBold (SB, 600)
-
-제목, 헤딩, 강조 텍스트에 사용됩니다.
-
-| 이름      | 설명          | 값               |
-| --------- | ------------- | ---------------- |
-| WD-SB_t1  | SemiBold 11px | 0.6875rem (11px) |
-| WD-SB_t5  | SemiBold 16px | 1rem (16px)      |
-| WD-SB_t10 | SemiBold 26px | 1.625rem (26px)  |
+<Canvas of={TypographyStories.TypoStory} />

--- a/src/styles/foundation/typography/typography.mdx
+++ b/src/styles/foundation/typography/typography.mdx
@@ -1,0 +1,131 @@
+import { Meta, Canvas } from "@storybook/blocks";
+import * as TypographyStories from "./typography.stories";
+
+<Meta of={TypographyStories} />
+
+# Typography System
+
+Woori Design System의 타이포그래피 시스템입니다.
+WDS는 모든 환경에서 일관된 타이포그래피를 제공합니다.
+
+<br />
+
+## Examples
+
+Woori Design System에서는 theme.typography 객체를 통해 타이포그래피 토큰을 JavaScript 객체로 제공합니다.
+
+React, Next.js 등 JS 기반 프로젝트에서는 아래와 같이 사용할 수 있습니다:
+
+```tsx
+import { theme } from "woori-design";
+
+const MyComponent = () => (
+  <div
+    style={{
+      fontFamily: theme.typography.Rg_t5.fontFamily,
+      fontWeight: theme.typography.Rg_t5.fontWeight,
+      fontSize: theme.typography.Rg_t5.fontSize,
+    }}
+  >
+    타이포그래피가 적용된 텍스트입니다.
+  </div>
+);
+```
+
+<br />
+
+## Typography Token System
+
+Woori Design System은 세 가지 주요 폰트 웨이트와 t1부터 t10까지의 체계적인 폰트 사이즈를 제공합니다.
+
+<br />
+
+### 1. Font Family
+
+우리 디자인 시스템은 **Pretendard**를 기본 폰트로 사용합니다.
+
+```css
+font-family: "Pretendard", "sans-serif";
+```
+
+### 2. Token Naming
+
+각 타이포그래피 토큰은 `WD-[웨이트]_t[사이즈]` 형식으로 명명됩니다.
+
+- **WD**: Woori Design의 약자
+- **[웨이트]**: Rg(Regular), Md(Medium), SB(SemiBold)
+- **t[사이즈]**: t1부터 t10까지의 사이즈 체계
+
+<br />
+
+### 3. Font Weights
+
+타이포그래피 시스템은 다음 세 가지 웨이트를 제공합니다:
+
+| 웨이트 코드 | 웨이트 이름 | 웨이트 값 |
+| ----------- | ----------- | --------- |
+| Rg          | Regular     | 400       |
+| Md          | Medium      | 500       |
+| SB          | SemiBold    | 600       |
+
+<br />
+
+### 4. Font Sizes
+
+타이포그래피 시스템은 t1부터 t10까지 10가지 사이즈를 제공합니다:
+
+| 사이즈 코드 | 픽셀 값 | rem 값    |
+| ----------- | ------- | --------- |
+| t1          | 11px    | 0.6875rem |
+| t2          | 12px    | 0.75rem   |
+| t3          | 13px    | 0.8125rem |
+| t4          | 14px    | 0.875rem  |
+| t5          | 16px    | 1rem      |
+| t6          | 18px    | 1.125rem  |
+| t7          | 20px    | 1.25rem   |
+| t8          | 22px    | 1.375rem  |
+| t9          | 24px    | 1.5rem    |
+| t10         | 26px    | 1.625rem  |
+
+<br />
+
+### 5. Line Height
+
+기본 라인 하이트는 1.5로 설정되어 있습니다. 필요에 따라 개별 토큰에 다른 라인 하이트를 지정할 수 있습니다.
+
+```typescriptreact
+// 기본 라인 하이트
+export const defaultLineHeight = 1.5;
+```
+
+### 6. Weight & Size Combinations
+
+#### (1) Regular (Rg, 400)
+
+기본 본문 텍스트에 사용됩니다. 대부분의 일반 텍스트 콘텐츠에 적합합니다.
+
+| 이름      | 설명         | 값               |
+| --------- | ------------ | ---------------- |
+| WD-Rg_t1  | Regular 11px | 0.6875rem (11px) |
+| WD-Rg_t5  | Regular 16px | 1rem (16px)      |
+| WD-Rg_t10 | Regular 26px | 1.625rem (26px)  |
+
+#### (2) Medium (Md, 500)
+
+중요도가 약간 높은 텍스트나 서브 헤딩에 사용됩니다.
+
+| 이름      | 설명        | 값               |
+| --------- | ----------- | ---------------- |
+| WD-Md_t1  | Medium 11px | 0.6875rem (11px) |
+| WD-Md_t5  | Medium 16px | 1rem (16px)      |
+| WD-Md_t10 | Medium 26px | 1.625rem (26px)  |
+
+#### (3) SemiBold (SB, 600)
+
+제목, 헤딩, 강조 텍스트에 사용됩니다.
+
+| 이름      | 설명          | 값               |
+| --------- | ------------- | ---------------- |
+| WD-SB_t1  | SemiBold 11px | 0.6875rem (11px) |
+| WD-SB_t5  | SemiBold 16px | 1rem (16px)      |
+| WD-SB_t10 | SemiBold 26px | 1.625rem (26px)  |

--- a/src/styles/foundation/typography/typography.stories.tsx
+++ b/src/styles/foundation/typography/typography.stories.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import { weightNames, getTypographyClassName, typography } from "./typography";
+import { FontWeight, TypographyToken } from "./typography.type";
+
+export const TypographyPreview = () => {
+  const [text, setText] = useState("우리디자인");
+  const [weightFilter, setWeightFilter] = useState<"all" | FontWeight>("all");
+
+  const weights = ["all", "Rg", "Md", "SB"] as const;
+  const sizes = Array.from({ length: 10 }, (_, i) => i + 1);
+
+  const allClassNames = weights
+    .filter((weight) => weight !== "all")
+    .flatMap((weight) =>
+      sizes.map((size) => {
+        const token = `${weight as FontWeight}_t${size}` as TypographyToken;
+        return {
+          weight: weight as FontWeight,
+          size,
+          token,
+          className: getTypographyClassName(token),
+          style: typography[token],
+        };
+      })
+    );
+
+  const filteredClassNames =
+    weightFilter === "all"
+      ? allClassNames
+      : allClassNames.filter((item) => item.weight === weightFilter);
+
+  const groupedByWeight = filteredClassNames.reduce((acc, item) => {
+    if (!acc[item.weight]) acc[item.weight] = [];
+    acc[item.weight].push(item);
+    return acc;
+  }, {} as Record<FontWeight, typeof allClassNames>);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "32px" }}>
+      <div
+        style={{
+          display: "flex",
+          gap: "16px",
+          alignItems: "center",
+          padding: "24px",
+          backgroundColor: "#f8f9fa",
+          borderRadius: "12px",
+          boxShadow: "0 1px 3px rgba(0,0,0,0.1)",
+        }}
+      >
+        <input
+          placeholder="텍스트를 입력해주세요..."
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          style={{
+            all: "unset",
+            border: "1px solid #d2d0d2",
+            borderRadius: "9999px",
+            padding: "16px 20px",
+            flexGrow: 1,
+            boxShadow: "inset 0 1px 2px rgba(0,0,0,0.05)",
+          }}
+        />
+        <div style={{ display: "flex", gap: "8px" }}>
+          {weights.map((weight) => (
+            <button
+              key={weight}
+              onClick={() => setWeightFilter(weight as "all" | FontWeight)}
+              style={{
+                padding: "10px 18px",
+                borderRadius: "8px",
+                border: "1px solid #d2d0d2",
+                background: weightFilter === weight ? "#4f46e5" : "white",
+                color: weightFilter === weight ? "white" : "#333",
+                fontWeight: 500,
+              }}
+            >
+              {weight === "all" ? "전체" : weight}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {Object.entries(groupedByWeight).map(([weight, items]) => (
+        <div key={weight} style={{ marginBottom: "32px" }}>
+          <h3
+            style={{
+              marginBottom: "16px",
+              padding: "8px 16px",
+              backgroundColor: "#f0f0f0",
+              borderRadius: "8px",
+              display: "inline-block",
+            }}
+          >
+            {weightNames[weight as FontWeight]}
+          </h3>
+
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "16px" }}
+          >
+            {items
+              .sort((a, b) => a.size - b.size)
+              .map((item) => (
+                <div
+                  key={item.className}
+                  style={{
+                    padding: "16px 24px",
+                    border: "1px solid #eee",
+                    borderRadius: "8px",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    backgroundColor: "white",
+                    boxShadow: "0 1px 3px rgba(0,0,0,0.05)",
+                  }}
+                >
+                  <div
+                    style={{
+                      fontFamily: item.style.fontFamily,
+                      fontWeight: item.style.fontWeight,
+                      fontSize: item.style.fontSize,
+                      lineHeight: item.style.lineHeight,
+                      letterSpacing: item.style.letterSpacing,
+                    }}
+                  >
+                    {text}
+                  </div>
+                  <code
+                    style={{
+                      fontSize: "12px",
+                      color: "#666",
+                      padding: "4px 8px",
+                      backgroundColor: "#f5f5f5",
+                      borderRadius: "4px",
+                    }}
+                  >
+                    {item.className}
+                  </code>
+                </div>
+              ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default {
+  title: "Foundation/Typography",
+  component: TypographyPreview,
+};

--- a/src/styles/foundation/typography/typography.stories.tsx
+++ b/src/styles/foundation/typography/typography.stories.tsx
@@ -1,151 +1,64 @@
-import { useState } from "react";
-import { weightNames, getTypographyClassName, typography } from "./typography";
-import { FontWeight, TypographyToken } from "./typography.type";
+import React, { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { typography } from "./typography";
+import { TypographyToken } from "./typography.type";
 
-export const TypographyPreview = () => {
-  const [text, setText] = useState("우리디자인");
-  const [weightFilter, setWeightFilter] = useState<"all" | FontWeight>("all");
-
-  const weights = ["all", "Rg", "Md", "SB"] as const;
-  const sizes = Array.from({ length: 10 }, (_, i) => i + 1);
-
-  const allClassNames = weights
-    .filter((weight) => weight !== "all")
-    .flatMap((weight) =>
-      sizes.map((size) => {
-        const token = `${weight as FontWeight}_t${size}` as TypographyToken;
-        return {
-          weight: weight as FontWeight,
-          size,
-          token,
-          className: getTypographyClassName(token),
-          style: typography[token],
-        };
-      })
-    );
-
-  const filteredClassNames =
-    weightFilter === "all"
-      ? allClassNames
-      : allClassNames.filter((item) => item.weight === weightFilter);
-
-  const groupedByWeight = filteredClassNames.reduce((acc, item) => {
-    if (!acc[item.weight]) acc[item.weight] = [];
-    acc[item.weight].push(item);
-    return acc;
-  }, {} as Record<FontWeight, typeof allClassNames>);
-
-  return (
-    <div style={{ display: "flex", flexDirection: "column", gap: "32px" }}>
-      <div
-        style={{
-          display: "flex",
-          gap: "16px",
-          alignItems: "center",
-          padding: "24px",
-          backgroundColor: "#f8f9fa",
-          borderRadius: "12px",
-          boxShadow: "0 1px 3px rgba(0,0,0,0.1)",
-        }}
-      >
-        <input
-          placeholder="텍스트를 입력해주세요..."
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          style={{
-            all: "unset",
-            border: "1px solid #d2d0d2",
-            borderRadius: "9999px",
-            padding: "16px 20px",
-            flexGrow: 1,
-            boxShadow: "inset 0 1px 2px rgba(0,0,0,0.05)",
-          }}
-        />
-        <div style={{ display: "flex", gap: "8px" }}>
-          {weights.map((weight) => (
-            <button
-              key={weight}
-              onClick={() => setWeightFilter(weight as "all" | FontWeight)}
-              style={{
-                padding: "10px 18px",
-                borderRadius: "8px",
-                border: "1px solid #d2d0d2",
-                background: weightFilter === weight ? "#4f46e5" : "white",
-                color: weightFilter === weight ? "white" : "#333",
-                fontWeight: 500,
-              }}
-            >
-              {weight === "all" ? "전체" : weight}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {Object.entries(groupedByWeight).map(([weight, items]) => (
-        <div key={weight} style={{ marginBottom: "32px" }}>
-          <h3
-            style={{
-              marginBottom: "16px",
-              padding: "8px 16px",
-              backgroundColor: "#f0f0f0",
-              borderRadius: "8px",
-              display: "inline-block",
-            }}
-          >
-            {weightNames[weight as FontWeight]}
-          </h3>
-
-          <div
-            style={{ display: "flex", flexDirection: "column", gap: "16px" }}
-          >
-            {items
-              .sort((a, b) => a.size - b.size)
-              .map((item) => (
-                <div
-                  key={item.className}
-                  style={{
-                    padding: "16px 24px",
-                    border: "1px solid #eee",
-                    borderRadius: "8px",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    backgroundColor: "white",
-                    boxShadow: "0 1px 3px rgba(0,0,0,0.05)",
-                  }}
-                >
-                  <div
-                    style={{
-                      fontFamily: item.style.fontFamily,
-                      fontWeight: item.style.fontWeight,
-                      fontSize: item.style.fontSize,
-                      lineHeight: item.style.lineHeight,
-                      letterSpacing: item.style.letterSpacing,
-                    }}
-                  >
-                    {text}
-                  </div>
-                  <code
-                    style={{
-                      fontSize: "12px",
-                      color: "#666",
-                      padding: "4px 8px",
-                      backgroundColor: "#f5f5f5",
-                      borderRadius: "4px",
-                    }}
-                  >
-                    {item.className}
-                  </code>
-                </div>
-              ))}
-          </div>
-        </div>
-      ))}
-    </div>
-  );
+const meta: Meta = {
+  title: "Foundation/Typos",
+  parameters: {
+    layout: "centered",
+  },
 };
 
-export default {
-  title: "Foundation/Typography",
-  component: TypographyPreview,
+export default meta;
+
+export const TypoStory: StoryObj = {
+  render: () => <TypoTestStory />,
+};
+
+const TypoTestStory = () => {
+  const [previewTxt, setPreviewTxt] = useState("가나다라마바사");
+
+  const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPreviewTxt(e.target.value);
+  };
+
+  const typoEntries = Object.entries(typography) as [TypographyToken, React.CSSProperties][];
+
+  return (
+    <div style={{ padding: "2rem", width: "100%", maxWidth: "800px" }}>
+      <h1 style={{ fontSize: "24px", marginBottom: "1rem" }}>Typography System</h1>
+      <input
+        type="text"
+        value={previewTxt}
+        onChange={handleInput}
+        placeholder="예시 텍스트 입력"
+        style={{
+          marginBottom: "2rem",
+          padding: "0.5rem",
+          fontSize: "16px",
+          width: "100%",
+          border: "1px solid #ccc",
+          borderRadius: "4px",
+        }}
+      />
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "160px minmax(520px, 1fr) 60px",
+          rowGap: "1.25rem",
+          columnGap: "1rem",
+        }}
+      >
+        {typoEntries.map(([token, style]) => (
+          <React.Fragment key={token}>
+            <div style={{ fontSize: "14px", color: "#666" }}>{token}</div>
+            <div style={style}>{previewTxt}</div>
+            <div style={{ fontSize: "14px", color: "#aaa" }}>{style.fontSize}</div>
+          </React.Fragment>
+        ))}
+      </div>
+    </div>
+  );
 };

--- a/src/styles/foundation/typography/typography.ts
+++ b/src/styles/foundation/typography/typography.ts
@@ -1,0 +1,225 @@
+import {
+  TypographyTokenMap,
+  WeightNameMap,
+  WeightValueMap,
+  SizePixelMap,
+  SizeRemMap,
+} from "./typography.type";
+
+export const fontFamily = '"Pretendard", sans-serif';
+
+export const weightNames: WeightNameMap = {
+  Rg: "Regular",
+  Md: "Medium",
+  SB: "SemiBold",
+};
+
+export const weightValues: WeightValueMap = {
+  Rg: 400,
+  Md: 500,
+  SB: 600,
+};
+
+export const sizePixels: SizePixelMap = {
+  t1: 11,
+  t2: 12,
+  t3: 13,
+  t4: 14,
+  t5: 16,
+  t6: 18,
+  t7: 20,
+  t8: 22,
+  t9: 24,
+  t10: 26,
+};
+
+export const sizeRems: SizeRemMap = {
+  t1: "0.6875rem",
+  t2: "0.75rem",
+  t3: "0.8125rem",
+  t4: "0.875rem",
+  t5: "1rem",
+  t6: "1.125rem",
+  t7: "1.25rem",
+  t8: "1.375rem",
+  t9: "1.5rem",
+  t10: "1.625rem",
+};
+
+export const defaultLineHeight = 1.5;
+
+export const typography: TypographyTokenMap = {
+  Rg_t1: {
+    fontFamily,
+    fontWeight: weightValues.Rg,
+    fontSize: sizeRems.t1,
+  },
+  Rg_t2: {
+    fontFamily,
+    fontWeight: weightValues.Rg,
+    fontSize: sizeRems.t2,
+  },
+  Rg_t3: {
+    fontFamily,
+    fontWeight: weightValues.Rg,
+    fontSize: sizeRems.t3,
+  },
+  Rg_t4: {
+    fontFamily,
+    fontWeight: weightValues.Rg,
+    fontSize: sizeRems.t4,
+  },
+  Rg_t5: {
+    fontFamily,
+    fontWeight: weightValues.Rg,
+    fontSize: sizeRems.t5,
+  },
+  Rg_t6: {
+    fontFamily,
+    fontWeight: weightValues.Rg,
+    fontSize: sizeRems.t6,
+  },
+  Rg_t7: {
+    fontFamily,
+    fontWeight: weightValues.Rg,
+    fontSize: sizeRems.t7,
+  },
+  Rg_t8: {
+    fontFamily,
+    fontWeight: weightValues.Rg,
+    fontSize: sizeRems.t8,
+  },
+  Rg_t9: {
+    fontFamily,
+    fontWeight: weightValues.Rg,
+    fontSize: sizeRems.t9,
+  },
+  Rg_t10: {
+    fontFamily,
+    fontWeight: weightValues.Rg,
+    fontSize: sizeRems.t10,
+  },
+
+  Md_t1: {
+    fontFamily,
+    fontWeight: weightValues.Md,
+    fontSize: sizeRems.t1,
+  },
+  Md_t2: {
+    fontFamily,
+    fontWeight: weightValues.Md,
+    fontSize: sizeRems.t2,
+  },
+  Md_t3: {
+    fontFamily,
+    fontWeight: weightValues.Md,
+    fontSize: sizeRems.t3,
+  },
+  Md_t4: {
+    fontFamily,
+    fontWeight: weightValues.Md,
+    fontSize: sizeRems.t4,
+  },
+  Md_t5: {
+    fontFamily,
+    fontWeight: weightValues.Md,
+    fontSize: sizeRems.t5,
+  },
+  Md_t6: {
+    fontFamily,
+    fontWeight: weightValues.Md,
+    fontSize: sizeRems.t6,
+  },
+  Md_t7: {
+    fontFamily,
+    fontWeight: weightValues.Md,
+    fontSize: sizeRems.t7,
+  },
+  Md_t8: {
+    fontFamily,
+    fontWeight: weightValues.Md,
+    fontSize: sizeRems.t8,
+  },
+  Md_t9: {
+    fontFamily,
+    fontWeight: weightValues.Md,
+    fontSize: sizeRems.t9,
+  },
+  Md_t10: {
+    fontFamily,
+    fontWeight: weightValues.Md,
+    fontSize: sizeRems.t10,
+  },
+
+  SB_t1: {
+    fontFamily,
+    fontWeight: weightValues.SB,
+    fontSize: sizeRems.t1,
+  },
+  SB_t2: {
+    fontFamily,
+    fontWeight: weightValues.SB,
+    fontSize: sizeRems.t2,
+  },
+  SB_t3: {
+    fontFamily,
+    fontWeight: weightValues.SB,
+    fontSize: sizeRems.t3,
+  },
+  SB_t4: {
+    fontFamily,
+    fontWeight: weightValues.SB,
+    fontSize: sizeRems.t4,
+  },
+  SB_t5: {
+    fontFamily,
+    fontWeight: weightValues.SB,
+    fontSize: sizeRems.t5,
+  },
+  SB_t6: {
+    fontFamily,
+    fontWeight: weightValues.SB,
+    fontSize: sizeRems.t6,
+  },
+  SB_t7: {
+    fontFamily,
+    fontWeight: weightValues.SB,
+    fontSize: sizeRems.t7,
+  },
+  SB_t8: {
+    fontFamily,
+    fontWeight: weightValues.SB,
+    fontSize: sizeRems.t8,
+  },
+  SB_t9: {
+    fontFamily,
+    fontWeight: weightValues.SB,
+    fontSize: sizeRems.t9,
+  },
+  SB_t10: {
+    fontFamily,
+    fontWeight: weightValues.SB,
+    fontSize: sizeRems.t10,
+  },
+};
+
+export const getTypography = (token: keyof typeof typography) => {
+  return typography[token];
+};
+
+export const getTypographyClassName = (token: keyof typeof typography) => {
+  return `WD-${token}`;
+};
+
+export const getTypographyStyle = (token: keyof typeof typography) => {
+  const style = typography[token];
+  return `
+      font-family: ${style.fontFamily};
+      font-weight: ${style.fontWeight};
+      font-size: ${style.fontSize};
+      ${style.lineHeight ? `line-height: ${style.lineHeight};` : ""}
+      ${style.letterSpacing ? `letter-spacing: ${style.letterSpacing};` : ""}
+    `;
+};
+
+export default typography;

--- a/src/styles/foundation/typography/typography.ts
+++ b/src/styles/foundation/typography/typography.ts
@@ -1,225 +1,31 @@
-import {
-  TypographyTokenMap,
-  WeightNameMap,
-  WeightValueMap,
-  SizePixelMap,
-  SizeRemMap,
-} from "./typography.type";
+import { CSSProperties } from "react";
+import type { TypographyToken, TypoType } from "./typography.type";
 
 export const fontFamily = '"Pretendard", sans-serif';
 
-export const weightNames: WeightNameMap = {
-  Rg: "Regular",
-  Md: "Medium",
-  SB: "SemiBold",
-};
-
-export const weightValues: WeightValueMap = {
+const fontWeightMap = {
   Rg: 400,
   Md: 500,
-  SB: 600,
-};
+  Sb: 600,
+} as const;
 
-export const sizePixels: SizePixelMap = {
-  t1: 11,
-  t2: 12,
-  t3: 13,
-  t4: 14,
-  t5: 16,
-  t6: 18,
-  t7: 20,
-  t8: 22,
-  t9: 24,
-  t10: 26,
-};
+const fontSizes = [11, 12, 14, 16, 18, 20, 22, 24, 26, 28, 32, 36, 48] as const;
+const fontWeightKeys = ["Rg", "Md", "Sb"] as const;
 
-export const sizeRems: SizeRemMap = {
-  t1: "0.6875rem",
-  t2: "0.75rem",
-  t3: "0.8125rem",
-  t4: "0.875rem",
-  t5: "1rem",
-  t6: "1.125rem",
-  t7: "1.25rem",
-  t8: "1.375rem",
-  t9: "1.5rem",
-  t10: "1.625rem",
-};
+export const typography = Object.fromEntries(
+  fontWeightKeys.flatMap((weight) =>
+    fontSizes.map((size) => {
+      const key = `${weight}_${size}` as TypographyToken;
 
-export const defaultLineHeight = 1.5;
+      const value: CSSProperties = {
+        fontFamily,
+        fontSize: `${size}px`,
+        fontStyle: "normal",
+        fontWeight: fontWeightMap[weight],
+        lineHeight: "normal",
+      };
 
-export const typography: TypographyTokenMap = {
-  Rg_t1: {
-    fontFamily,
-    fontWeight: weightValues.Rg,
-    fontSize: sizeRems.t1,
-  },
-  Rg_t2: {
-    fontFamily,
-    fontWeight: weightValues.Rg,
-    fontSize: sizeRems.t2,
-  },
-  Rg_t3: {
-    fontFamily,
-    fontWeight: weightValues.Rg,
-    fontSize: sizeRems.t3,
-  },
-  Rg_t4: {
-    fontFamily,
-    fontWeight: weightValues.Rg,
-    fontSize: sizeRems.t4,
-  },
-  Rg_t5: {
-    fontFamily,
-    fontWeight: weightValues.Rg,
-    fontSize: sizeRems.t5,
-  },
-  Rg_t6: {
-    fontFamily,
-    fontWeight: weightValues.Rg,
-    fontSize: sizeRems.t6,
-  },
-  Rg_t7: {
-    fontFamily,
-    fontWeight: weightValues.Rg,
-    fontSize: sizeRems.t7,
-  },
-  Rg_t8: {
-    fontFamily,
-    fontWeight: weightValues.Rg,
-    fontSize: sizeRems.t8,
-  },
-  Rg_t9: {
-    fontFamily,
-    fontWeight: weightValues.Rg,
-    fontSize: sizeRems.t9,
-  },
-  Rg_t10: {
-    fontFamily,
-    fontWeight: weightValues.Rg,
-    fontSize: sizeRems.t10,
-  },
-
-  Md_t1: {
-    fontFamily,
-    fontWeight: weightValues.Md,
-    fontSize: sizeRems.t1,
-  },
-  Md_t2: {
-    fontFamily,
-    fontWeight: weightValues.Md,
-    fontSize: sizeRems.t2,
-  },
-  Md_t3: {
-    fontFamily,
-    fontWeight: weightValues.Md,
-    fontSize: sizeRems.t3,
-  },
-  Md_t4: {
-    fontFamily,
-    fontWeight: weightValues.Md,
-    fontSize: sizeRems.t4,
-  },
-  Md_t5: {
-    fontFamily,
-    fontWeight: weightValues.Md,
-    fontSize: sizeRems.t5,
-  },
-  Md_t6: {
-    fontFamily,
-    fontWeight: weightValues.Md,
-    fontSize: sizeRems.t6,
-  },
-  Md_t7: {
-    fontFamily,
-    fontWeight: weightValues.Md,
-    fontSize: sizeRems.t7,
-  },
-  Md_t8: {
-    fontFamily,
-    fontWeight: weightValues.Md,
-    fontSize: sizeRems.t8,
-  },
-  Md_t9: {
-    fontFamily,
-    fontWeight: weightValues.Md,
-    fontSize: sizeRems.t9,
-  },
-  Md_t10: {
-    fontFamily,
-    fontWeight: weightValues.Md,
-    fontSize: sizeRems.t10,
-  },
-
-  SB_t1: {
-    fontFamily,
-    fontWeight: weightValues.SB,
-    fontSize: sizeRems.t1,
-  },
-  SB_t2: {
-    fontFamily,
-    fontWeight: weightValues.SB,
-    fontSize: sizeRems.t2,
-  },
-  SB_t3: {
-    fontFamily,
-    fontWeight: weightValues.SB,
-    fontSize: sizeRems.t3,
-  },
-  SB_t4: {
-    fontFamily,
-    fontWeight: weightValues.SB,
-    fontSize: sizeRems.t4,
-  },
-  SB_t5: {
-    fontFamily,
-    fontWeight: weightValues.SB,
-    fontSize: sizeRems.t5,
-  },
-  SB_t6: {
-    fontFamily,
-    fontWeight: weightValues.SB,
-    fontSize: sizeRems.t6,
-  },
-  SB_t7: {
-    fontFamily,
-    fontWeight: weightValues.SB,
-    fontSize: sizeRems.t7,
-  },
-  SB_t8: {
-    fontFamily,
-    fontWeight: weightValues.SB,
-    fontSize: sizeRems.t8,
-  },
-  SB_t9: {
-    fontFamily,
-    fontWeight: weightValues.SB,
-    fontSize: sizeRems.t9,
-  },
-  SB_t10: {
-    fontFamily,
-    fontWeight: weightValues.SB,
-    fontSize: sizeRems.t10,
-  },
-};
-
-export const getTypography = (token: keyof typeof typography) => {
-  return typography[token];
-};
-
-export const getTypographyClassName = (token: keyof typeof typography) => {
-  return `WD-${token}`;
-};
-
-export const getTypographyStyle = (token: keyof typeof typography) => {
-  const style = typography[token];
-  return `
-      font-family: ${style.fontFamily};
-      font-weight: ${style.fontWeight};
-      font-size: ${style.fontSize};
-      ${style.lineHeight ? `line-height: ${style.lineHeight};` : ""}
-      ${style.letterSpacing ? `letter-spacing: ${style.letterSpacing};` : ""}
-    `;
-};
-
-export default typography;
+      return [key, value] as const;
+    })
+  )
+) as TypoType;

--- a/src/styles/foundation/typography/typography.type.ts
+++ b/src/styles/foundation/typography/typography.type.ts
@@ -1,0 +1,47 @@
+export type FontWeight = "Rg" | "Md" | "SB";
+
+export type FontSize =
+  | "t1"
+  | "t2"
+  | "t3"
+  | "t4"
+  | "t5"
+  | "t6"
+  | "t7"
+  | "t8"
+  | "t9"
+  | "t10";
+
+export type TypographyToken = `${FontWeight}_${FontSize}`;
+
+export interface TypographyStyle {
+  fontFamily: string;
+  fontWeight: number;
+  fontSize: string;
+  lineHeight?: string;
+  letterSpacing?: string;
+}
+
+export interface TypographyTokenMap {
+  [key in TypographyToken]: TypographyStyle;
+}
+
+export interface WeightNameMap {
+  Rg: string;
+  Md: string;
+  SB: string;
+}
+
+export interface WeightValueMap {
+  Rg: number;
+  Md: number;
+  SB: number;
+}
+
+export interface SizePixelMap {
+  [key in FontSize]: number;
+}
+
+export interface SizeRemMap {
+  [key in FontSize]: string;
+}

--- a/src/styles/foundation/typography/typography.type.ts
+++ b/src/styles/foundation/typography/typography.type.ts
@@ -1,47 +1,9 @@
-export type FontWeight = "Rg" | "Md" | "SB";
+import { CSSProperties } from "react";
 
-export type FontSize =
-  | "t1"
-  | "t2"
-  | "t3"
-  | "t4"
-  | "t5"
-  | "t6"
-  | "t7"
-  | "t8"
-  | "t9"
-  | "t10";
+export type FontWeight = "Rg" | "Md" | "Sb";
+
+export type FontSize = 11 | 12 | 14 | 16 | 18 | 20 | 22 | 24 | 26 | 28 | 32 | 36 | 48;
 
 export type TypographyToken = `${FontWeight}_${FontSize}`;
 
-export interface TypographyStyle {
-  fontFamily: string;
-  fontWeight: number;
-  fontSize: string;
-  lineHeight?: string;
-  letterSpacing?: string;
-}
-
-export interface TypographyTokenMap {
-  [key in TypographyToken]: TypographyStyle;
-}
-
-export interface WeightNameMap {
-  Rg: string;
-  Md: string;
-  SB: string;
-}
-
-export interface WeightValueMap {
-  Rg: number;
-  Md: number;
-  SB: number;
-}
-
-export interface SizePixelMap {
-  [key in FontSize]: number;
-}
-
-export interface SizeRemMap {
-  [key in FontSize]: string;
-}
+export type TypoType = Record<TypographyToken, CSSProperties>;

--- a/src/styles/theme/theme.tsx
+++ b/src/styles/theme/theme.tsx
@@ -10,5 +10,5 @@ export const theme: ThemeType = {
   semantic: {
     color: semanticColors,
   },
-  typography: typography,
+  typo: typography,
 };

--- a/src/styles/theme/theme.tsx
+++ b/src/styles/theme/theme.tsx
@@ -1,5 +1,6 @@
 import { primitiveColors } from "../foundation/color/primitiveColor/primitiveColor";
 import { semanticColors } from "../foundation/color/semanticColor/semanticColor";
+import { typography } from "../foundation/typography/typography";
 import { ThemeType } from "./theme.type";
 
 export const theme: ThemeType = {
@@ -9,4 +10,5 @@ export const theme: ThemeType = {
   semantic: {
     color: semanticColors,
   },
+  typography: typography,
 };

--- a/src/styles/theme/theme.type.ts
+++ b/src/styles/theme/theme.type.ts
@@ -1,5 +1,6 @@
 import { PrimitiveColors } from "../foundation/color/primitiveColor/primitiveColor.type";
 import { SemanticColorsByTheme } from "../foundation/color/semanticColor/semanticColor.type";
+import { TypographyTokenMap } from "../foundation/typography/typography.type";
 
 export type ThemeType = {
   primitive: {
@@ -8,4 +9,5 @@ export type ThemeType = {
   semantic: {
     color: SemanticColorsByTheme;
   };
+  typography: TypographyTokenMap;
 };

--- a/src/styles/theme/theme.type.ts
+++ b/src/styles/theme/theme.type.ts
@@ -1,6 +1,6 @@
 import { PrimitiveColors } from "../foundation/color/primitiveColor/primitiveColor.type";
 import { SemanticColorsByTheme } from "../foundation/color/semanticColor/semanticColor.type";
-import { TypographyTokenMap } from "../foundation/typography/typography.type";
+import { TypoType } from "../foundation/typography/typography.type";
 
 export type ThemeType = {
   primitive: {
@@ -9,5 +9,5 @@ export type ThemeType = {
   semantic: {
     color: SemanticColorsByTheme;
   };
-  typography: TypographyTokenMap;
+  typo: TypoType;
 };


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)
| 수정 전 | 수정 후 |
|:-----:|:------:|
| ![image](https://github.com/user-attachments/assets/124de88c-0a97-4f53-ad3c-a1a471605e4c) | <img width="785" alt="image" src="https://github.com/user-attachments/assets/d2509c1a-8ca4-456b-9011-6067352fc5ec" /> |
| ![image](https://github.com/user-attachments/assets/b46d7e15-fc62-420b-80a8-72c84818cb5c) | <img width="937" alt="image" src="https://github.com/user-attachments/assets/34d35351-a0fb-4a35-899f-8a4800752dda" /> |

- resolved #5 

## 2️⃣ 알아두시면 좋아요!
- Pretendard를 기본 폰트로 사용하고, Regular / Medium / SemiBold 세 가지 weight와 t1~t10의 10단계 크기 시스템으로 토큰 구조를 정의했습니다. 
- 디자인 시스템 내에서 일관된 사용을 위해 WD-[Weight]_t[Size] 네이밍 규칙을 도입했습니다.
- theme.typography : 각 토큰에 대해 fontFamily, fontWeight, fontSize, lineHeight, letterSpacing 등을 포함
- Storybook 내에 Typography Preview 부분에 미리보기 기능을 제공하는 페이지를 만들어뒀습니다.

## 3️⃣ 추후 작업
- 논의 필요

## 4️⃣ 체크리스트 (Checklist)

- [x] `dev` 브랜치의 최신 코드를 `pull` 받았나요?
