### PR TITLE
fix: 빌드 및 배포 방식 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woori-design",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "description": "A React component library for FloatButton and others",
   "type": "module",
   "main": "dist/index.cjs.js",
@@ -53,5 +53,8 @@
     "woori-group"
   ],
   "author": "1223v",
-  "license": "MIT"
+  "license": "MIT",
+  "sideEffects": [
+    "dist/index.css"
+  ]
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,16 @@
 import "./App.css";
-import FloatButton from "./libs/floatbutton/FloatButton";
+import { theme } from "./styles/theme/theme";
 
 function App() {
   return (
-    <div>
-      <FloatButton
-        icon="❓"
-        position="center"
-        size="large"
-        onClick={() => alert("Help clicked!")}
-      />
+    <div
+      style={{
+        backgroundColor: theme.semantic.color.light.lightAlternative,
+        width: "100px",
+        height: "100px",
+      }}
+    >
+      시멘틱 컬러가 적용된 박스입니다.
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,1 @@
-@import "./styles/colors.css";
-@import "./styles/spacing.css";
-@import "./styles/typography.css";
 @import "./libs/floatbutton/FloatButton.module.css";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
-import "./styles/colors.css";
-import "./styles/spacing.css";
-import "./styles/typography.css";
+import "./index.css";
 
+export { theme } from "./styles/theme/theme";
 export { default as FloatButton } from "./libs/floatbutton/FloatButton";
 export { default as Divider } from "./libs/divider/divider";
 export { default as Checkbox } from "./libs/checkbox/Checkbox";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,12 +15,12 @@ export default defineConfig({
     rollupOptions: {
       external: ["react", "react-dom"],
       output: {
+        assetFileNames: "index.[ext]",
         globals: {
           react: "React",
           "react-dom": "ReactDOM",
         },
       },
     },
-    cssCodeSplit: true,
   },
 });


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)
- `vite.config.ts` 빌드 방식(cssCodeSplit: true -> css import 방식) 변경



### 기존 코드에 영향을 미치는 변경사항
CSS 파일은 전역에 스타일을 입히는 사이드 이펙트이므로, 번들러가 임의로 제거하지 못하도록 sideEffects에 추가했습니다.
- 이 CSS 파일은 트리 쉐이킹으로 제거하면 안 되도록 수정했습니다.(사용되는지 안 되는지 코드 분석으로 판단할 수 없으니, 무조건 포함)


### 버그 픽스
- `import "./index.css";`를 라이브러리 엔트리 파일(index.ts)에서 해주므로써 라이브러리 전체 공통 스타일을 자동으로 로드했습니다.
- Vite에서 assetFileNames: "index.[ext]"로 지정해, 생성되는 에셋 파일의 최종 이름이 "index.css", "index.png" 등 고정된 형태로 나오도록 했습니다. => 이로 인해 빌드 시 자동으로 생성되는 style.css 문제를 index.css로 설정해 index.css를 제어할 수 있게끔 변경했습니다.
- 기존 `cssCodeSplit: true` (css injection 방식)는 nextjs의 ssr 방식과 맞지 않다고 판단되어, 삭제했습니다.

## 2️⃣ 알아두시면 좋아요!
```
import { FloatButton, theme } from "woori-design";
import "woori-design/dist/index.css";
```
형태로 작성하시면 됩니다.

- https://www.npmjs.com/package/woori-design
- 테스트 버전 업데이트 해놨습니다. 다시금 다운로드 부탁드립니다.(v.0.0.36 -> v.0.0.37)

## 3️⃣ 추후 작업
- babel-plugin-import(특정 라이브러리로부터 컴포넌트를 임포트할 때, 해당 컴포넌트에 필요한 CSS 파일도 자동으로 함께 임포트)를 통한 import "woori-design/dist/index.css"; 제거

## 4️⃣ 체크리스트 (Checklist)

- [x] `dev` 브랜치의 최신 코드를 `pull` 받았나요?
