### PR TITLE
feat: 버튼 컴포넌트 colorScheme 속성 추가

### DIFF
--- a/src/libs/button/Button.mdx
+++ b/src/libs/button/Button.mdx
@@ -50,6 +50,20 @@ import { Button } from "woori-design";
 
 ## 예시
 
+### colorScheme
+
+Button의 컬러 속성을 지정합니다.
+
+`primary`, `secondary` 총 2가지의 컬러 속성을 가집니다.
+
+```tsx
+<Button size="large" variant="box" colorScheme="secondary">
+  large/box
+</Button>
+```
+
+<Canvas of={ButtonStories.ColorScheme} />
+
 ### rounded
 
 버튼의 border-radius 값을 나타냅니다.

--- a/src/libs/button/Button.module.css
+++ b/src/libs/button/Button.module.css
@@ -10,8 +10,8 @@
   font-style: normal;
   font-weight: 600;
   line-height: 1.4;
-  background-color: var(--color-light-lightassistive);
-  color: var(--color-dark-darknormal);
+  background-color: var(--color-dark-darknormal);
+  color: var(--color-bw-white);
 }
 
 .button:hover {
@@ -20,8 +20,8 @@
 }
 
 .button:active {
-  background-color: var(--color-dark-darknormal);
-  color: var(--color-bw-white);
+  background-color: var(--color-light-lightassistive);
+  color: var(--color-dark-darknormal);
 }
 
 .button:disabled {
@@ -87,4 +87,14 @@
 
 .button--rounded-100 {
   border-radius: 100px;
+}
+
+.button--secondary {
+  background-color: var(--color-light-lightassistive);
+  color: var(--color-dark-darknormal);
+}
+
+.button--secondary:active {
+  background-color: var(--color-dark-darknormal);
+  color: var(--color-bw-white);
 }

--- a/src/libs/button/Button.stories.tsx
+++ b/src/libs/button/Button.stories.tsx
@@ -51,6 +51,25 @@ export const Size: Story = {
   ),
 };
 
+export const ColorScheme: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: "24px" }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: "5px", alignItems: "center" }}>
+        <h4>colorScheme="primary"</h4>
+        <Button size="large" variant="box" rounded={16}>
+          large/box
+        </Button>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: "5px", alignItems: "center" }}>
+        <h4>colorScheme="secondary"</h4>
+        <Button size="large" variant="box" colorScheme="secondary" rounded={16}>
+          large/box
+        </Button>
+      </div>
+    </div>
+  ),
+};
+
 export const Variant: Story = {
   render: () => (
     <div style={{ display: "flex", gap: "24px" }}>

--- a/src/libs/button/Button.tsx
+++ b/src/libs/button/Button.tsx
@@ -9,6 +9,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
     size,
     width,
     variant = "box",
+    colorScheme = "primary",
     rounded = 16,
     children,
     onClick,
@@ -19,6 +20,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
     styles[`button--${size}`],
     variant === "text" && styles["button--text"],
     styles[`button--rounded-${rounded}`],
+    colorScheme === "secondary" && styles["button--secondary"],
   ]
     .filter(Boolean)
     .join(" ");

--- a/src/libs/button/Button.type.ts
+++ b/src/libs/button/Button.type.ts
@@ -1,5 +1,6 @@
 export type ButtonSize = "xlarge" | "large" | "medium" | "small" | "xsmall";
 export type ButtonVariant = "box" | "text";
+export type ButtonColorScheme = "primary" | "secondary";
 export type ButtonRounded = 16 | 100;
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -7,5 +8,6 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   width?: string;
   children?: React.ReactNode;
   variant: ButtonVariant;
+  colorScheme?: ButtonColorScheme;
   rounded?: ButtonRounded;
 }


### PR DESCRIPTION
## 1️⃣ 어떤 작업을 했나요? (Summary)

- resolved #26 

![스크린샷 2025-07-04 오후 1 08 03](https://github.com/user-attachments/assets/ad78d1ae-9549-4b47-b49b-57dbad2c151d)

## 2️⃣ 알아두시면 좋아요!
기존 한 가지 컬러로만 지정되어있던 버튼 컴포넌트를 더 다양한 곳에서 사용하기 위해 colorScheme 속성을 추가하여 primary와 secondary 총 두 가지의 컬러를 가질 수 있도록 하였습니다. 당장 만들 계획인 dialog에도 활용될 예정입니다.

## 4️⃣ 체크리스트 (Checklist)

- [x] `dev` 브랜치의 최신 코드를 `pull` 받았나요?
